### PR TITLE
[Bug] Filter Deleted Contact Activities From The App (SC-187130)

### DIFF
--- a/src/components/ActivitiesMainView.tsx
+++ b/src/components/ActivitiesMainView.tsx
@@ -42,7 +42,10 @@ export const ActivitiesMainView = ({
         return
       };
 
-      setActivities(activitiesReq.data ?? [])
+      // Filter out deleted activities.
+      const activeActivities = activitiesReq.data.filter((activity)=> activity.active_flag === true)
+
+      setActivities(activeActivities)
     } catch (error) {
       setActivities([]);
     } finally {

--- a/src/components/ActivitiesMainView.tsx
+++ b/src/components/ActivitiesMainView.tsx
@@ -77,8 +77,7 @@ export const ActivitiesMainView = ({
         <Fragment key={activity.id}>
           <Title
             title={activity.subject}
-            // Pipedrive doesn't have a direct link you can navigate to so we send the user to the activities list
-            link={`https://${deskproUser?.orgName}.pipedrive.com/activities/list/user/everyone?person_id=${activity.person_id}`}
+            link={`https://${deskproUser?.orgName}.pipedrive.com/activities/list/user/everyone?selected=${activity.id}`}
             icon={<PipedriveLogo />}
           />
           <TwoColumn

--- a/src/components/ActivitiesMainView.tsx
+++ b/src/components/ActivitiesMainView.tsx
@@ -43,7 +43,7 @@ export const ActivitiesMainView = ({
       };
 
       // Filter out deleted activities.
-      const activeActivities = activitiesReq.data.filter((activity)=> activity.active_flag === true)
+      const activeActivities = activitiesReq.data.filter((activity)=> activity.is_deleted !== true)
 
       setActivities(activeActivities)
     } catch (error) {

--- a/src/types/pipedrive/pipedriveActivity.ts
+++ b/src/types/pipedrive/pipedriveActivity.ts
@@ -13,6 +13,7 @@ export interface IPipedriveActivity {
     duration: string;
     busy_flag: null;
     add_time: string;
+    is_deleted: boolean;
     marked_as_done_time: string;
     last_notification_time: null;
     last_notification_user_id: null;


### PR DESCRIPTION
## Description
This PR fixes a bug where contact activities deleted in Pipedrive persisted in the app.

## Evidence


https://github.com/user-attachments/assets/aa896b0f-2750-409d-8718-76a08af7dc42

